### PR TITLE
add registration shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "implementation.js",
     "loader.js",
     "register.js",
-    "register-shim.js"
+    "register-shim.js",
+    "register/**"
   ],
   "keywords": [
     "observable",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "loader.js",
     "register.js",
     "register-shim.js",
-    "register/**"
+    "register"
   ],
   "keywords": [
     "observable",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,26 @@ Observable.of(1, 2).forEach(x => console.log(x));
 //=> 2
 ```
 
+## Registration Shortcuts
+
+This adds the following shortcut registrations:
+
+- `rxjs-min`: Bare bones rxjs implementation.
+- `rxjs`: Same as `rxjs-min`, but adds the somewhat standard `Observable.of` and `Observable.from`.
+- `rxjs-all`: The kitchen sink approach to Observables.
+- `zen`: The `zen-observable` implementation.
+
+Shortcut registration can be done as follows:
+
+```js
+import 'any-observable/register/zen';
+```
+
+It's especially handy for more recent versions of Node (and many test runners), that offer a `--require` flag:
+
+```
+$ ava --require any-observable/register/zen test.js
+```
 
 ## Related
 

--- a/register/rxjs-all.js
+++ b/register/rxjs-all.js
@@ -1,0 +1,2 @@
+'use strict';
+require('../register')('rxjs', {Observable: require('rxjs').Observable});

--- a/register/rxjs-min.js
+++ b/register/rxjs-min.js
@@ -1,0 +1,2 @@
+'use strict';
+require('../register')('rxjs/Observable', {Observable: require('rxjs/Observable').Observable});

--- a/register/rxjs.js
+++ b/register/rxjs.js
@@ -1,0 +1,4 @@
+'use strict';
+require('../register')('rxjs/Observable', {Observable: require('rxjs/Observable').Observable});
+require('rxjs/add/observable/of');
+require('rxjs/add/observable/from');

--- a/register/zen.js
+++ b/register/zen.js
@@ -1,0 +1,2 @@
+'use strict';
+require('../register')('zen-observable', {Observable: require('zen-observable')});

--- a/test/shortcut-rxjs-all.js
+++ b/test/shortcut-rxjs-all.js
@@ -1,0 +1,11 @@
+import '../register/rxjs-all';
+import test from 'ava';
+import {Observable as RxJsObservable} from 'rxjs';
+import AnyObservable from '../';
+import implementation from '../implementation';
+
+test(t => {
+	t.is(AnyObservable, RxJsObservable);
+	t.is(implementation, 'rxjs');
+	t.is(typeof RxJsObservable.prototype.map, 'function');
+});

--- a/test/shortcut-rxjs-min.js
+++ b/test/shortcut-rxjs-min.js
@@ -1,0 +1,13 @@
+import '../register/rxjs-min';
+import test from 'ava';
+import {Observable as RxJsObservable} from 'rxjs/Observable';
+import AnyObservable from '../';
+import implementation from '../implementation';
+
+test(t => {
+	t.is(AnyObservable, RxJsObservable);
+	t.is(implementation, 'rxjs/Observable');
+	t.is(typeof RxJsObservable.of, 'undefined');
+	t.is(typeof RxJsObservable.from, 'undefined');
+	t.is(typeof RxJsObservable.prototype.map, 'undefined');
+});

--- a/test/shortcut-rxjs.js
+++ b/test/shortcut-rxjs.js
@@ -1,0 +1,13 @@
+import '../register/rxjs';
+import test from 'ava';
+import {Observable as RxJsObservable} from 'rxjs/Observable';
+import AnyObservable from '../';
+import implementation from '../implementation';
+
+test(t => {
+	t.is(AnyObservable, RxJsObservable);
+	t.is(implementation, 'rxjs/Observable');
+	t.is(typeof RxJsObservable.of, 'function');
+	t.is(typeof RxJsObservable.from, 'function');
+	t.is(typeof RxJsObservable.prototype.map, 'undefined');
+});

--- a/test/shortcut-zen.js
+++ b/test/shortcut-zen.js
@@ -1,0 +1,10 @@
+import '../register/zen';
+import test from 'ava';
+import ZenObservable from 'zen-observable';
+import AnyObservable from '../';
+import implementation from '../implementation';
+
+test(t => {
+	t.is(AnyObservable, ZenObservable);
+	t.is(implementation, 'zen-observable');
+});


### PR DESCRIPTION
Fixes #2 

This adds the following shortcut registrations:
- `rxjs-min`: Bare bones rxjs implementation.
- `rxjs`: Same as `rxjs-min`, but adds the somewhat standard `Observable.of` and `Observable.from`.
- `rxjs-all`: The kitchen sink approach to Observables.
- `zen`: The `zen-observable` implementation.

Shortcut registration can be done as follows:

``` js
import `any-observable/register/zen`;
```

It's especially handy for more recent versions of Node (and many test runners), that offer a `--require` flag:

```
$ ava --require any-observable/register/zen test.js
```
