### PR TITLE
[WIP]: optional registration

### DIFF
--- a/optional.js
+++ b/optional.js
@@ -1,0 +1,36 @@
+var objectAssign = require('object-assign');
+
+try {
+	var registration = require('./register')();
+
+	module.exports = function () {
+		// defensive copy
+		return objectAssign(
+			{
+				registrationFound: true,
+				Throwing: registration.Observable
+			},
+			registration
+		);
+	};
+} catch (err) {
+	var create = function (obj, insert) {
+		obj.Observable = obj.implementation = null;
+		obj.registrationFound = false;
+		obj.Throwing = function AnyObservableThrowingFallback() {
+			throw new Error(
+				'You attempted to use a feature' + insert + ' that requires Observable support, ' +
+				'but no Observable implementations were found. Please install a global Observable polyfill or register an ' +
+				'observable implementation (i.e.: require(\'any-observable/register\')(\'rxjs\') ). ' +
+				'You must register it prior to loading any application code or calls to require(\'any-observable/optional\').'
+			);
+		};
+		return obj;
+	};
+
+	var base = function (name) {
+		return create({}, ' of ' + JSON.stringify(name));
+	};
+
+	module.exports = create(base, '');
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.7",
+    "proxyquire": "^1.7.4",
     "rxjs": "^5.0.0-beta.7",
     "watchify": "^3.7.0",
     "xo": "*",
@@ -59,5 +60,8 @@
         ]
       }
     ]
+  },
+  "dependencies": {
+    "object-assign": "^4.1.0"
   }
 }

--- a/test/defaults-fallback-to-zen.js
+++ b/test/defaults-fallback-to-zen.js
@@ -1,0 +1,16 @@
+const proxyquire = require('proxyquire');
+
+const optional = proxyquire('../optional', {
+	'rxjs': null,
+	'rxjs/Observable': null,
+	'@global': true
+})();
+
+const test = require('ava');
+const ZenObservable = require('zen-observable');
+
+test(t => {
+	t.is(optional.Observable, ZenObservable);
+	t.is(optional.implementation, 'zen-observable');
+	t.true(optional.registrationFound);
+});

--- a/test/global-observable.js
+++ b/test/global-observable.js
@@ -1,0 +1,17 @@
+function NotReallyAnObservable() {
+
+}
+
+global.Observable = NotReallyAnObservable;
+
+require('../register')('global.Observable');
+
+var test = require('ava');
+
+var AnyObservable = require('../');
+var implementation = require('../implementation');
+
+test(t => {
+	t.is(AnyObservable, NotReallyAnObservable);
+	t.is(implementation, 'global.Observable');
+});

--- a/test/optional.js
+++ b/test/optional.js
@@ -1,0 +1,26 @@
+const proxyquire = require('proxyquire');
+
+const optional = proxyquire('../optional', {
+	'rxjs': null,
+	'rxjs/Observable': null,
+	'zen-observable': null,
+	'@global': true
+});
+
+const myLib = optional('my-lib');
+
+const test = require('ava');
+
+test('general use', t => {
+	t.is(optional.Observable, null);
+	t.is(optional.implementation, null);
+	t.is(optional.registrationFound, false);
+	t.throws(optional.Throwing, /You attempted to use a feature that requires Observable support/);
+});
+
+test('named use', t => {
+	t.is(myLib.Observable, null);
+	t.is(myLib.implementation, null);
+	t.is(myLib.registrationFound, false);
+	t.throws(myLib.Throwing, /You attempted to use a feature of "my-lib" that requires Observable support/);
+});


### PR DESCRIPTION
This is an idea I had for optional registration. Basically I see two potential scenarios for libraries that have "optional" support.
1. All functionality of the library is supported without Observables, but the presence of a registered implementation will cause it to be enhanced some way. For this, the libraries docs would say: "If there is an Observable implementation registered, `returnValue.observable` will contain an Observable event stream for XXX."
2. Some methods exported by the library work without Observable support, some do not. In this case, the libraries documentation would say "This method throws an error if no Observable implementation is registered".

Usage:

``` js
const registration : OptionalRegistration = require('any-observable/optional');

interface OptionalRegistration {
  implementation: string;
  Observable: Function | null;
  registrationFound: boolean;
  Throwing: Function
}
```

The only new / interesting idea here is the `Throwing` function. If an implementation is found, it will just be the Observable constructor (i.e. `Throwing` === `Observable`). If not, it will be a function that throws a good error message when called.

This would help with `2` from above. Instead of libraries needing to incorporate logic checking if `optional` returned a registration or not, and generating their own errors. They can just import the Throwing constructor:

``` js
var Observable = require('any-observable/optional').Throwing;

module.exports.needsObservable = function () {
  return new Observable(...); // throws with a helpful message if no implementation found.
}
```

I have also included logic to allow the error message to reference which library requires Observable support:

``` js
// If registration does not exist, thrown errors will reference 'my-lib';
var Observable = require('any-observable/optional')('my-lib').Throwing;
```
## 

There's a part of me that thinks this just isn't worth it. That `optional` should just return `Observable` or `null`. Especially since that's where I think the `any-promise` equivalent is headed.

cc: @kevinbeaty
## 

Note: This adds a few tests that need to land regardless. They use proxyquire to test the auto-load behavior when `rxjs` is not available. And one for `global.Observable`.
