### PR TITLE
Add support for rxjs@6 - fixes #18

### DIFF
--- a/register.js
+++ b/register.js
@@ -38,7 +38,7 @@ function loadImplementation(implementation) {
 
 function tryAutoDetect() {
 	const libs = [
-		'rxjs/Observable',
+		'rxjs',
 		'zen-observable'
 	];
 

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -1,9 +1,9 @@
 const test = require('ava');
-const RxJsObservable = require('rxjs/Observable').Observable;
+const RxJsObservable = require('rxjs').Observable;
 const AnyObservable = require('..');
 const implementation = require('../implementation');
 
 test(t => {
 	t.is(AnyObservable, RxJsObservable);
-	t.is(implementation, 'rxjs/Observable');
+	t.is(implementation, 'rxjs');
 });


### PR DESCRIPTION
Not sure if this is the best way, but it still works for rxjs@5. If someone has an idea how we can test this against both versions of RxJS, feel free to add a suggestion.

I was in doubt if we should add `rxjs` as a separate item from `rxjs/Observable`. But I didn't do it because the current solution also works for version 5. But I can still do this if it's preferred.