### PR TITLE
Support RxJS 6

### DIFF
--- a/browser/tests/shortcut-rxjs-all.js
+++ b/browser/tests/shortcut-rxjs-all.js
@@ -1,14 +1,17 @@
 require('../../register/rxjs-all'); // eslint-disable-line import/no-unassigned-import
 
 const assert = require('assert');
-const RxJsObservable = require('rxjs/Observable').Observable;
+const RxJsObservable = require('rxjs').Observable;
+const RxJsOf = require('rxjs').of;
+const RxJsFrom = require('rxjs').from;
+const RxJsMap = require('rxjs/operators').map;
 const AnyObservable = require('../..');
 const implementation = require('../../implementation');
 
 it('rxjs-all', () => {
 	assert.strictEqual(AnyObservable, RxJsObservable);
 	assert.strictEqual(implementation, 'rxjs');
-	assert.strictEqual(typeof RxJsObservable.of, 'function');
-	assert.strictEqual(typeof RxJsObservable.from, 'function');
-	assert.strictEqual(typeof RxJsObservable.prototype.map, 'function');
+	assert.strictEqual(typeof RxJsOf, 'function');
+	assert.strictEqual(typeof RxJsFrom, 'function');
+	assert.strictEqual(typeof RxJsMap, 'function');
 });

--- a/browser/tests/shortcut-rxjs-min.js
+++ b/browser/tests/shortcut-rxjs-min.js
@@ -1,13 +1,13 @@
 require('../../register/rxjs-min'); // eslint-disable-line import/no-unassigned-import
 
 const assert = require('assert');
-const RxJsObservable = require('rxjs/Observable').Observable;
+const RxJsObservable = require('rxjs').Observable;
 const AnyObservable = require('../..');
 const implementation = require('../../implementation');
 
 it('rxjs', () => {
 	assert.strictEqual(AnyObservable, RxJsObservable);
-	assert.strictEqual(implementation, 'rxjs/Observable');
+	assert.strictEqual(implementation, 'rxjs');
 	assert.strictEqual(typeof RxJsObservable.of, 'undefined');
 	assert.strictEqual(typeof RxJsObservable.from, 'undefined');
 	assert.strictEqual(typeof RxJsObservable.prototype.map, 'undefined');

--- a/browser/tests/shortcut-rxjs.js
+++ b/browser/tests/shortcut-rxjs.js
@@ -1,14 +1,16 @@
 require('../../register/rxjs'); // eslint-disable-line import/no-unassigned-import
 
 const assert = require('assert');
-const RxJsObservable = require('rxjs/Observable').Observable;
+const RxJsObservable = require('rxjs').Observable;
+const RxJsOf = require('rxjs').of;
+const RxJsFrom = require('rxjs').from;
 const AnyObservable = require('../..');
 const implementation = require('../../implementation');
 
 it('rxjs-min', () => {
 	assert.strictEqual(AnyObservable, RxJsObservable);
-	assert.strictEqual(implementation, 'rxjs/Observable');
-	assert.strictEqual(typeof RxJsObservable.of, 'function');
-	assert.strictEqual(typeof RxJsObservable.from, 'function');
+	assert.strictEqual(implementation, 'rxjs');
+	assert.strictEqual(typeof RxJsOf, 'function');
+	assert.strictEqual(typeof RxJsFrom, 'function');
 	assert.strictEqual(typeof RxJsObservable.prototype.map, 'undefined');
 });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"karma-chrome-launcher": "^2.2.0",
 		"karma-mocha": "^1.3.0",
 		"mocha": "^6.1.4",
-		"rxjs": "^5.5.10",
+		"rxjs": "^6.5.3",
 		"watchify": "^3.11.0",
 		"xo": "^0.24.0",
 		"zen-observable": "^0.8.8"

--- a/register-shim.js
+++ b/register-shim.js
@@ -9,7 +9,9 @@ To register a custom implementation, use the `Observable` option.
 */
 function loadImplementation() {
 	if (typeof window.Observable === 'undefined') {
-		throw new TypeError('any-observable browser requires a polyfill or explicit registration, for example:\nrequire(\'any-observable/register\')(\'rxjs\', {Observable: require(\'rxjs/Observable\').Observable})');
+		throw new TypeError(
+			'any-observable browser requires a polyfill or explicit registration, for example:\nrequire("any-observable/register")("rxjs", {Observable: require("rxjs").Observable})'
+		);
 	}
 
 	return {

--- a/register/rxjs-min.js
+++ b/register/rxjs-min.js
@@ -1,2 +1,4 @@
 'use strict';
-require('../register')('rxjs/Observable', {Observable: require('rxjs/Observable').Observable});
+require('../register')('rxjs', {
+	Observable: require('rxjs').Observable
+});

--- a/register/rxjs.js
+++ b/register/rxjs.js
@@ -1,4 +1,6 @@
 'use strict';
-require('../register')('rxjs/Observable', {Observable: require('rxjs/Observable').Observable});
-require('rxjs/add/observable/of'); // eslint-disable-line import/no-unassigned-import
-require('rxjs/add/observable/from'); // eslint-disable-line import/no-unassigned-import
+require('../register')('rxjs', {
+	Observable: require('rxjs').Observable
+});
+require('rxjs').of; // eslint-disable-line no-unused-expressions
+require('rxjs').from; // eslint-disable-line no-unused-expressions

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const RxJsObservable = require('rxjs').Observable;
-const AnyObservable = require('..');
 const implementation = require('../implementation');
+const AnyObservable = require('..');
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);

--- a/test/rxjs-observable.js
+++ b/test/rxjs-observable.js
@@ -1,10 +1,10 @@
-require('../register')('rxjs/Observable');
+require('../register')('rxjs');
 const test = require('ava');
-const RxJsObservable = require('rxjs/Observable').Observable;
-const AnyObservable = require('..');
+const RxJsObservable = require('rxjs').Observable;
 const implementation = require('../implementation');
+const AnyObservable = require('..');
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);
-	t.is(implementation, 'rxjs/Observable');
+	t.is(implementation, 'rxjs');
 });

--- a/test/rxjs.js
+++ b/test/rxjs.js
@@ -1,8 +1,8 @@
 require('../register')('rxjs');
 const test = require('ava');
 const RxJsObservable = require('rxjs').Observable;
-const AnyObservable = require('..');
 const implementation = require('../implementation');
+const AnyObservable = require('..');
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);

--- a/test/shortcut-rxjs-all.js
+++ b/test/shortcut-rxjs-all.js
@@ -1,11 +1,12 @@
 import '../register/rxjs-all'; // eslint-disable-line import/no-unassigned-import
 import test from 'ava';
 import {Observable as RxJsObservable} from 'rxjs';
-import AnyObservable from '..';
+import {map} from 'rxjs/operators';
 import implementation from '../implementation';
+import AnyObservable from '..';
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);
 	t.is(implementation, 'rxjs');
-	t.is(typeof RxJsObservable.prototype.map, 'function');
+	t.is(typeof map, 'function');
 });

--- a/test/shortcut-rxjs-min.js
+++ b/test/shortcut-rxjs-min.js
@@ -1,12 +1,12 @@
 import '../register/rxjs-min'; // eslint-disable-line import/no-unassigned-import
 import test from 'ava';
-import {Observable as RxJsObservable} from 'rxjs/Observable';
-import AnyObservable from '..';
+import {Observable as RxJsObservable} from 'rxjs';
 import implementation from '../implementation';
+import AnyObservable from '..';
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);
-	t.is(implementation, 'rxjs/Observable');
+	t.is(implementation, 'rxjs');
 	t.is(typeof RxJsObservable.of, 'undefined');
 	t.is(typeof RxJsObservable.from, 'undefined');
 	t.is(typeof RxJsObservable.prototype.map, 'undefined');

--- a/test/shortcut-rxjs.js
+++ b/test/shortcut-rxjs.js
@@ -1,13 +1,17 @@
 import '../register/rxjs'; // eslint-disable-line import/no-unassigned-import
 import test from 'ava';
-import {Observable as RxJsObservable} from 'rxjs/Observable';
-import AnyObservable from '..';
+import {
+	Observable as RxJsObservable,
+	of as RxJsOf,
+	from as RxJsFrom
+} from 'rxjs';
 import implementation from '../implementation';
+import AnyObservable from '..';
 
 test('main', t => {
 	t.is(AnyObservable, RxJsObservable);
-	t.is(implementation, 'rxjs/Observable');
-	t.is(typeof RxJsObservable.of, 'function');
-	t.is(typeof RxJsObservable.from, 'function');
+	t.is(implementation, 'rxjs');
+	t.is(typeof RxJsOf, 'function');
+	t.is(typeof RxJsFrom, 'function');
 	t.is(typeof RxJsObservable.prototype.map, 'undefined');
 });

--- a/test/shortcut-zen.js
+++ b/test/shortcut-zen.js
@@ -1,8 +1,8 @@
 import '../register/zen'; // eslint-disable-line import/no-unassigned-import
 import test from 'ava';
 import ZenObservable from 'zen-observable';
-import AnyObservable from '..';
 import implementation from '../implementation';
+import AnyObservable from '..';
 
 test('main', t => {
 	t.is(AnyObservable, ZenObservable);

--- a/test/zen.js
+++ b/test/zen.js
@@ -1,8 +1,8 @@
 require('../register')('zen-observable');
 const test = require('ava');
 const ZenObservable = require('zen-observable');
-const AnyObservable = require('..');
 const implementation = require('../implementation');
+const AnyObservable = require('..');
 
 test('main', t => {
 	t.is(AnyObservable, ZenObservable);


### PR DESCRIPTION
Closes #22.

The PR is in draft state for now, since I didn't have the time yet to test it on an actual project. 
Can I `yarn link` to test it?

I had `rxjs-compat` installed at first to make it a smooth transition and removed it again, so support for RxJS 5 is definitely dropped.

Sorry for all the changes in a single commit, I kind of unexpectedly managed to get it working and passing all the tests right away :)

Looking forward to get some feedback.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#22: Support RxJS 6](https://issuehunt.io/repos/57201062/issues/22)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->