### PR TITLE
Add missing optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,6 @@
 		"any",
 		"rxjs"
 	],
-	"peerDependenciesMeta": {
-		"rxjs": {
-			"optional": true
-		},
-		"zen-observable": {
-			"optional": true
-		}
-	},
 	"devDependencies": {
 		"arrify": "^2.0.1",
 		"ava": "^1.4.1",
@@ -53,6 +45,14 @@
 		"watchify": "^3.11.0",
 		"xo": "^0.24.0",
 		"zen-observable": "^0.8.8"
+	},
+	"peerDependenciesMeta": {
+		"rxjs": {
+			"optional": true
+		},
+		"zen-observable": {
+			"optional": true
+		}
 	},
 	"browser": {
 		"./register.js": "./register-shim.js"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
 		"any",
 		"rxjs"
 	],
+	"peerDependenciesMeta": {
+		"rxjs": {
+			"optional": true
+		},
+		"zen-observable": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"arrify": "^2.0.1",
 		"ava": "^1.4.1",


### PR DESCRIPTION
This diff adds the missing **optional** peer dependencies on `rxjs` and `zen-observable`. Without that, Yarn will refuse giving `any-observable` access to the dependencies.

Because it only uses `peerDependenciesMeta` (and not `peerDependencies`), this diff is entirely compatible with other package managers (it won't cause warning to appear anywhere).